### PR TITLE
Make changes required to get developers up and running

### DIFF
--- a/api/src/data/database-manager.ts
+++ b/api/src/data/database-manager.ts
@@ -5,12 +5,13 @@ import {config} from "../config/config";
 /**
  * The DatabaseManager manages a connection to the PostgreSQL database.
  */
+console.log(config.database);
 export class DatabaseManager {
   pool = new Pool({
     connectionString: config.database,
-    ssl: {
+    ssl: config.database.indexOf('@localhost') === -1 ? {
       rejectUnauthorized: false
-    }
+    } : false
   });
 
   /**

--- a/editor/nuxt.config.js
+++ b/editor/nuxt.config.js
@@ -212,16 +212,16 @@ export default {
   ** See https://nuxtjs.org/api/configuration-build/
   */
   build: {
-    plugins: [
-      new MonacoWebpackPlugin({
-        features: [
-          '!goToDefinitionCommands',
-          '!goToDefinitionMouse',
-          '!referenceSearch'
-        ],
-        languages: ['css', 'html'],
-      })
-    ],
+    // plugins: [
+    //   new MonacoWebpackPlugin({
+    //     features: [
+    //       '!goToDefinitionCommands',
+    //       '!goToDefinitionMouse',
+    //       '!referenceSearch'
+    //     ],
+    //     languages: ['css', 'html'],
+    //   })
+    // ],
     extend(config, ctx) {
       // const vue = ctx.loaders.vue;
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.0",
   "private": true,
   "scripts": {
-    "build": "cd editor;nuxt-ts build;cd ../server;tsc && npm run copy;",
+    "build": "cd editor && npm run build && cd ../api && npm run build && cd ../renderer && npm run build",
     "setup": "node setup.js"
   },
   "dependencies": {

--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,7 @@ git clone https://github.com/Neutron-Creative/Singlelink.git
 2. Install the dependencies with NPM
 
 ```bash
-cd client;npm install;cd ../server;npm install;cd ../;
+cd api;npm install;cd ../editor;npm install;cd ../renderer;npm install;cd ../
 ```
 
 3. Run the setup script
@@ -73,8 +73,28 @@ npm run setup
 
 4. Build & launch <a target="_blank" href="https://singlelink.co">Singlelink</a>
 
+Build all the modules
+
 ```bash
-npm run build;npm run start;
+npm run build
+```
+
+Start the API in one terminal:
+
+```bash
+cd api; npm run start;
+```
+
+Start the editor in another terminal:
+
+```bash
+cd editor; PORT=8080 API_URL=http://localhost:5566 npm run start
+```
+
+Start the renderer in another terminal:
+
+```bash
+cd renderer; PORT=8081 API_URL=http://localhost:5566 npm run start
 ```
 
 ### Development setup
@@ -92,7 +112,7 @@ git clone https://github.com/Neutron-Creative/Singlelink.git
 2. Install the dependencies with NPM
 
 ```bash
-cd client;npm install;cd ../server;npm install;cd ../;
+cd api;npm install;cd ../editor;npm install;cd ../renderer;npm install;cd ../
 ```
 
 3. Run the setup script
@@ -103,8 +123,22 @@ npm run setup
 
 4. Launch <a target="_blank" href="https://singlelink.co">Singlelink</a> with hot-reloading enabled
 
+Start the API in one terminal:
+
 ```bash
-npm run dev
+cd api; npm run dev;
+```
+
+Start the editor in another terminal:
+
+```bash
+cd editor; PORT=8080 API_URL=http://localhost:5566 npm run dev
+```
+
+Start the renderer in another terminal:
+
+```bash
+cd renderer; PORT=8081 API_URL=http://localhost:5566 npm run dev
 ```
 
 ## Screenshots

--- a/setup.js
+++ b/setup.js
@@ -41,7 +41,7 @@ prompt.get(schema, function(err, result) {
         return;
     }
     log('');
-    log('About to write to ./server/src/config.json:');
+    log('About to write to ./api/src/config.json:');
     log('');
     log(result);
     log('');
@@ -98,7 +98,7 @@ prompt.get(schema, function(err, result) {
         result['clientDomain'] = result.host + ':80';
 
         try {
-            fs.writeFileSync('./server/src/config.json', JSON.stringify(result))
+            fs.writeFileSync('./api/src/config.json', JSON.stringify(result))
         } catch(err) {
             log(err);
             log('');


### PR DESCRIPTION
I gave up on docker-compose, and instead opted to just run each of the projects directly on the host. I still wrapped postgres in a container using:

```bash
docker run -p 5432:5432 --name some-postgres -e POSTGRES_PASSWORD=postgres -d postgres
```

That way I could set the postgres url as:
```
postgresql://postgres:password@postgres/postgres
```

Even after all the changes to the build scripts, I was unable to get a build of the editor working with the MonacoWebpackPlugin. It failed with errors like this:
![image](https://user-images.githubusercontent.com/608054/126513867-fd7de466-dc4f-4fc7-904d-ec28766ac41b.png)

Is there a trick to getting the editor building on a fresh clone?

I was using Node.js version `v14.15.4` if it helps reproing.