### PR TITLE
Temporarily fix #232

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "camelize-ts": "^1.0.8",
     "eslint": "8.8.0",
     "eslint-config-next": "12.0.10",
-    "graphql": "^15.8.0",
+    "graphql": "^15.7.2",
     "graphql-codegen": "^0.4.0",
     "postcss": "^8.4.6",
     "tailwindcss": "^3.0.21",


### PR DESCRIPTION
Fix issue #232 by changing minimum graphql version to 15.7.2 so that app can be easily deployed to Railway without needing edits to package-lock.